### PR TITLE
Fate card improvements

### DIFF
--- a/documents/en/core-rules.md
+++ b/documents/en/core-rules.md
@@ -1435,18 +1435,20 @@ A player can play any of their cards whenever appropriate. A played card is disc
 
 There are no limits to how many of a given card a player can own, but they may only hoard a maximum of 5 cards at a time. 
 
-| Cost    | Name               | Effect             |
-| ------- | ------------------ | ------------------ |
-| 3 MiFP  | Single Re-Roll     | Repeat a single test you just made. |
-| 6 MiFP  | Clotter            | One **active** [injury](#injury) of choice is now **patched up**. |
-| 1 MaFP  | Cascading Re-Roll  | Repeat a single test you just made. With this card, you keep any **positives** you achieved from the previously made test and add them to the **positives** rolled when you repeat the test. |
-| 1 MaFP  | Fact Check         | Change a minor plot point in a way your prefer. Work with your **GM** to make sure it fits the narrative, but they should respect your wish. This could be something like avoiding an **NPC** death or changing a fact about the plot. |
-| 1 MaFP  | Hastened           | +1 **AP** during your turns for the entirety of a [combat](#combat) encounter. |
-| 3 MaFP  | Double the Fun     | Double the number of dice to roll on your next/current test and every rolled **positive** counts double - which means every rolled **positive** actually counts as 2 **positives**! |
-| 3 MaFP  | Just a Flesh Wound | Remove or avoid one non-permanent [injury](#injury) of choice. |
-| 10 MaFP | Wrong Diagnosis    | Remove or avoid one permanent [injury](#injury) of choice. |
-| 1 AFP   | Defy Death         | Leap from [death's door](#deaths-door), remove 1 **active** [injury](#injury) of choice and be at 1 **HP**; Alternatively, avoid a narratively-driven death. The **GM** will decide the character's alternative fate. They could be captured, very badly injured or become indebted to someone or something. |
-| 1 AFP   | Yes, my liege      | Work with your **GM** to create a follower/hireling who will now be at your command/employ. |
+| Cost    | Name                | Effect             |
+| ------- | ------------------- | ------------------ |
+| 2 MiFP  | Single Re-Roll      | Repeat a single test you just made. |
+| 6 MiFP  | Clotter             | One **active** [injury](#injury) of choice is now **patched up**. |
+| 6 MiFP  | Cascading Re-Roll   | Repeat a single test you just made. With this card, you keep any **positives** you achieved from the previously made test and add them to the **positives** rolled when you repeat the test. |
+| 8 MiFP  | Learning Boost      | For the duration of the session, you gain **twice** the [progress](#advancing-skills) towards your [learning skills](#learning-skills) whenever you test them. |
+| 8 MiFP  | Hastened            | +1 **AP** during your turns for the entirety of a [combat](#combat) encounter. |
+| 2 MaFP  | Fact Check          | Change a minor plot point in a way your prefer. Work with your **GM** to make sure it fits the narrative, but they should respect your wish. This could be something like avoiding an **NPC** death or changing a fact about the plot. |
+| 3 MaFP  | Double the Fun      | Double the number of dice to roll on your next/current test and every rolled **positive** counts double - which means every rolled **positive** actually counts as 2 **positives**! |
+| 3 MaFP  | Scar? What Scar?    | Remove one scar [scar](#scars) of choice. |
+| 4 MaFP  | Incorrect Diagnosis | Avoid an [injury](#injury) as it would be inflicted upon you - you do not suffer that [injury](#injury)! |
+| 5 MaFP  | Just a Flesh Wound  | Raise your injury limit by one for the duration of an encounter. This card can also be played as you suffer an [injury](#injury) and even when you're [dying](#deaths-door). In that case, playing this card counts as a successful test and brings you back from the verge of death. |
+| 1 AFP   | Defy Death          | Leap from [death's door](#deaths-door), remove 1 **active** [injury](#injury) of choice and be at 1 **HP**; Alternatively, avoid a narratively-driven death. The **GM** will decide the character's alternative fate. They could be captured, very badly injured or become indebted to someone or something. Note that this card can only be played *after* the character lost their [battle with death](#deaths-door). |
+| 1 AFP   | Yes, my liege       | Work with your **GM** to create a follower/hireling who will now be at your command/employ. |
 
 # Time-Management
 The speed at which time flows, in-game, is variable and depends on the current circumstances of the narrative. 


### PR DESCRIPTION
* "Single Re-Roll" cost down to 2 MiFP, from 3 MiFP
* "Cascading Re-Roll" cost down to 6 MiFP, from 1 MaFP
* New fate card "Learning Boost"
* "Hastened" cost down to 8 MiFP, from 1 MaFP
* Fact Check cost up to 2 MaFP, from 1 MaFP
* New fate card "Scar? What Scar?"
* "Wrong Diagnosis" is now "Incorrect Diagnosis" and costs 4 MaFP, up from 3 MaFP
* "Just a Flesh Wound" cost up to 5 MaFP, from 3 MaFP

References to "permanent injuries" were removed and a new use found for the cards. 

Closes #169 